### PR TITLE
Include "origin" field when creating bag via POST request

### DIFF
--- a/bagdiscovery/serializers.py
+++ b/bagdiscovery/serializers.py
@@ -21,7 +21,7 @@ class BagSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Bag
-        fields = ('url', 'bag_identifier', 'bag_path', 'accession', 'data', 'created', 'last_modified')
+        fields = ('url', 'bag_identifier', 'bag_path', 'origin', 'accession', 'data', 'created', 'last_modified')
 
 
 class BagListSerializer(serializers.HyperlinkedModelSerializer):

--- a/bagdiscovery/tests.py
+++ b/bagdiscovery/tests.py
@@ -111,16 +111,26 @@ class BagTestCase(TestCase):
             self.assertEqual(response.status_code, 200, "Response error: {}".format(response.data))
 
     def test_bag_creation(self):
-        bag_data = {
-            "bag_data": "foobar",
-            "origin": "aurora",
-            "bag_identifier": "123456"
-        }
-        request = self.factory.post(reverse('bag-list'), bag_data, format='json')
-        response = BagViewSet.as_view(actions={"post": "create"})(request)
-        # for key, value in bag_data.items():
-        #     self.assertEqual(response.json()[key], bag_data[key])
-        self.assertEqual(response.status_code, 201, "Response error: {}".format(response.data))
+        BAG_DATAS = [
+            {
+                "origin": "aurora",
+                "bag_identifier": "123456"
+            },
+            {
+                "origin": "digitization",
+                "bag_identifier": "654321"
+            },
+            {
+                "origin": "legacy_digital",
+                "bag_identifier": "12345"
+            }
+        ]
+        for bag_data in BAG_DATAS:
+            request = self.factory.post(reverse('bag-list'), bag_data, format='json')
+            response = BagViewSet.as_view(actions={"post": "create"})(request)
+            for key, value in bag_data.items():
+                self.assertEqual(response.data[key], bag_data[key])
+            self.assertEqual(response.status_code, 201, "Response error: {}".format(response.data))
 
     def test_schema(self):
         """Tests the schema view."""

--- a/bagdiscovery/tests.py
+++ b/bagdiscovery/tests.py
@@ -111,6 +111,7 @@ class BagTestCase(TestCase):
             self.assertEqual(response.status_code, 200, "Response error: {}".format(response.data))
 
     def test_bag_creation(self):
+        """Ensures that bag model instances are properly created via POST requests."""
         BAG_DATAS = [
             {
                 "origin": "aurora",

--- a/bagdiscovery/tests.py
+++ b/bagdiscovery/tests.py
@@ -118,6 +118,8 @@ class BagTestCase(TestCase):
         }
         request = self.factory.post(reverse('bag-list'), bag_data, format='json')
         response = BagViewSet.as_view(actions={"post": "create"})(request)
+        # for key, value in bag_data.items():
+        #     self.assertEqual(response.json()[key], bag_data[key])
         self.assertEqual(response.status_code, 201, "Response error: {}".format(response.data))
 
     def test_schema(self):


### PR DESCRIPTION
Fixes #141 

I was having trouble figuring out how to parse the data out of the request response in tests, so I left what I was trying to do in comments.